### PR TITLE
Extract the call to compressRUCS outside of the for of loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,10 +194,14 @@ async function Main () {
       // Eliminamos los archivos txt y zip, dejamos solo .sql
       await ctrlFileExists(`${_PATHTXT}/${txtFile}`)
       await ctrlFileExists(`${_PATHZIP}/${zipFile}`)
-      await compressRUCS()
     } catch (error) {
       console.log(`Error en la funcion Main(). Mensaje: ${error.message}, ${error.stack}`)
     }
+  }
+  try {
+    await compressRUCS()
+  } catch (error) {
+      console.log(`Error en la funcion Main(). Mensaje: ${error.message}, ${error.stack}`)
   }
 }
 


### PR DESCRIPTION
On first run the program will display an error because it can't find all
the ruc*.sql files.

Extracting the call will also increase the performance slightly, because
it will only be called once, after all the *.sql files are available.